### PR TITLE
[feat] #15 퀴즈 생성 post api 구현

### DIFF
--- a/mobile3/src/main/java/sopkathon/mobile3/common/dto/message/SuccessMessage.java
+++ b/mobile3/src/main/java/sopkathon/mobile3/common/dto/message/SuccessMessage.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
 
 
-    MEMBER_CREATE_SUCCESS(HttpStatus.CREATED.value(),"멤버 생성 완료");
+    MEMBER_CREATE_SUCCESS(HttpStatus.CREATED.value(),"멤버 생성 완료"),
+    QUIZ_CREATE_SUCCESS(HttpStatus.CREATED.value(),"퀴즈 생성 완료");
+
     private final int status;
     private final String message;
 }

--- a/mobile3/src/main/java/sopkathon/mobile3/member/controller/MemberController.java
+++ b/mobile3/src/main/java/sopkathon/mobile3/member/controller/MemberController.java
@@ -25,6 +25,6 @@ public class MemberController {
 
     @GetMapping("/main")
     public ResponseEntity<GetMainResponseDto> getMain(@RequestBody GetMainRequestDto requestDto) {
-        return ResponseEntity.ok(memberService.getMain(requestDto));
+        return ResponseEntity.ok(memberService.findMain(requestDto));
     }
 }

--- a/mobile3/src/main/java/sopkathon/mobile3/member/controller/MemberController.java
+++ b/mobile3/src/main/java/sopkathon/mobile3/member/controller/MemberController.java
@@ -18,7 +18,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/member")
-    @Operation(summary = "닉네임과 타겟 필드로 멤버를 생성하는 API", description = "닉네임과 타겟 필드로 멤버를 생성하는 로직을 처리합니다.")
+    @Operation(summary = "닉네임과 친해지고픈 친구 필드를 이용해 멤버를 생성하는 API", description = "닉네임과 친해지고픈 친구 필드를 이용해 멤버를 생성합니다")
     public ResponseEntity<SuccessStatusResponse> createMember(@RequestBody MemberCreateRequestDto requestDto) {
         return ResponseEntity.ok(memberService.create(requestDto));
     }

--- a/mobile3/src/main/java/sopkathon/mobile3/member/service/MemberService.java
+++ b/mobile3/src/main/java/sopkathon/mobile3/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package sopkathon.mobile3.member.service;
 
-import com.sun.net.httpserver.Authenticator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import sopkathon.mobile3.common.dto.SuccessStatusResponse;
@@ -24,9 +23,15 @@ public class MemberService {
         return SuccessStatusResponse.of(SuccessMessage.MEMBER_CREATE_SUCCESS);
     }
 
-    public GetMainResponseDto getMain(GetMainRequestDto requestDto) {
+    public GetMainResponseDto findMain(GetMainRequestDto requestDto) {
         return GetMainResponseDto.of(memberRepository.findById(requestDto.memberId()).orElseThrow(
                 () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
         ));
+    }
+
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new NotFoundException((ErrorMessage.MEMBER_NOT_FOUND))
+        );
     }
 }

--- a/mobile3/src/main/java/sopkathon/mobile3/quiz/controller/QuizController.java
+++ b/mobile3/src/main/java/sopkathon/mobile3/quiz/controller/QuizController.java
@@ -1,0 +1,30 @@
+package sopkathon.mobile3.quiz.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopkathon.mobile3.common.dto.SuccessStatusResponse;
+import sopkathon.mobile3.common.dto.message.SuccessMessage;
+import sopkathon.mobile3.quiz.service.QuizService;
+import sopkathon.mobile3.quiz.service.dto.QuizCreateRequest;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @PostMapping("/quiz")
+    @Operation(summary = "멤버 아이디로 퀴즈를 생성하는 API", description = "멤버 아이디를 RequestBody로 받아 퀴즈를 생성합니다.")
+    public ResponseEntity<SuccessStatusResponse> createQuiz(@RequestBody QuizCreateRequest quizCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", quizService.createQuiz(quizCreateRequest.memberId()))
+                .body(SuccessStatusResponse.of(SuccessMessage.QUIZ_CREATE_SUCCESS));
+    }
+}

--- a/mobile3/src/main/java/sopkathon/mobile3/quiz/service/QuizService.java
+++ b/mobile3/src/main/java/sopkathon/mobile3/quiz/service/QuizService.java
@@ -1,0 +1,24 @@
+package sopkathon.mobile3.quiz.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopkathon.mobile3.member.domain.Member;
+import sopkathon.mobile3.member.service.MemberService;
+import sopkathon.mobile3.quiz.domain.Quiz;
+import sopkathon.mobile3.quiz.repository.QuizRepository;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+
+    private final QuizRepository quizRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public String createQuiz(Long memberId) {
+        Member member = memberService.findById(memberId);
+        Quiz quiz = quizRepository.save(Quiz.create(null, member));
+        return quiz.getQuizId().toString();
+    }
+}

--- a/mobile3/src/main/java/sopkathon/mobile3/quiz/service/dto/QuizCreateRequest.java
+++ b/mobile3/src/main/java/sopkathon/mobile3/quiz/service/dto/QuizCreateRequest.java
@@ -1,0 +1,4 @@
+package sopkathon.mobile3.quiz.service.dto;
+
+public record QuizCreateRequest(Long memberId) {
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #13 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 퀴즈를 생성하는 API를 구현하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 퀴즈 생성 완료
![image](https://github.com/SOPKATHON-iOS-TEAM3/Sopkathon-SERVER/assets/125895298/0f94ca6f-45ce-493c-a314-32375f6e6ac0)

### 존재하지 않는 멤버 아이디로 퀴즈를 생성하려 할 때
![image](https://github.com/SOPKATHON-iOS-TEAM3/Sopkathon-SERVER/assets/125895298/ed79a3ae-3f73-4619-94b9-d1a5e21378c5)

### 하나를 초과하여 퀴즈를 생성하려고 할 때
![image](https://github.com/SOPKATHON-iOS-TEAM3/Sopkathon-SERVER/assets/125895298/d5e86e19-1109-4b97-abc5-dfb799e6b3c7)


## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->